### PR TITLE
Fix release workflow permissions for creating releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   release:
     name: Build and Release
     runs-on: macos-26
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Add contents: write permission at job level to allow GITHUB_TOKEN to create releases and tags.